### PR TITLE
enabled selection of virtual folders as startup folders

### DIFF
--- a/content/tbsortfolders.xul
+++ b/content/tbsortfolders.xul
@@ -200,7 +200,7 @@
               </menupopup>
             </menulist>
             <menulist id="startupFolder" label="&extra.nofolder;" oncommand="on_pick_folder(event);" flex="1">
-              <menupopup id="startupFolderPopup" type="folder" mode="filing"
+              <menupopup id="startupFolderPopup" type="folder"
                          showFileHereLabel="true"
                          fileHereLabel="&extra.usethisfolder;"/>
             </menulist>


### PR DESCRIPTION
by removing `mode="filing"` from the startup-folder popup, the user is now able to select virtual folders (previously known as *saved searches*) as startup folders.