### PR TITLE
Some fixes towards TB 60.0 compatibilty.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,12 @@
 -- v0.6 development series --
 
 New bugfix with collapsing folders by default. Fix appearance of the tree.
+
+-- v1.1.2b --
+
+Fixed some JS compatibilty problems with Thunerbird 60 (mainly about Application
+preference interfaces and restart). UI for account sorting works, folder sorting
+is still broken, but writing to folder sort preference is inhibited so we don't
+risk destroying existing sort order. Also using "pretty names" instead of
+"prettiest names" as the latter is deprecated and in practice identical to the
+first.

--- a/content/folderPane.js
+++ b/content/folderPane.js
@@ -11,7 +11,7 @@
     .getService(Ci.nsIPrefService)
     .getBranch("extensions.tbsortfolders@xulforum.org.");
   /* This array is populated either when the file is loaded or when the
-   * preferences are updated. The keys are the account's prettiest names and the
+   * preferences are updated. The keys are the account's pretty names and the
    * values are the sort functions associated to each account. */
   var tbsf_prefs_functions;
 
@@ -24,7 +24,7 @@
     //In case we're asked to sort sub-folders, we walk up the tree up to the root
     //item which is the "fake folder" representing the account.
     while (parent.parent) parent = parent.parent;
-    let parentName = parent.prettiestName;
+    let parentName = parent.prettyName;
 
     let sort_function;
     if (tbsf_prefs_functions[parentName]) {

--- a/content/tbsortfolders.xul
+++ b/content/tbsortfolders.xul
@@ -6,13 +6,13 @@
 <!DOCTYPE window SYSTEM "chrome://tbsortfolders/locale/ui.dtd">
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
         title="&general.title;" onload="on_load();">
-  <script type="application/x-javascript" src="ui.js" />
+  <script type="application/javascript" src="ui.js" />
 
   <description style="font-weight: bold; color: #c00; display: none;" id="err_no_accounts">
     &accountsort.noaccountsetupyet;
   </description>
 
-  <tabbox selectedIndex="1" flex="1">
+  <tabbox selectedIndex="0" flex="1">
     <tabs>
       <tab><label value="&tab.accounts;" /></tab>
       <tab><label value="&tab.folders;" /></tab>

--- a/install.rdf
+++ b/install.rdf
@@ -6,11 +6,12 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>tbsortfolders@xulforum.org</em:id>
-    <em:version>1.1.1</em:version>
+    <em:version>1.1.2b</em:version>
     <em:iconURL>chrome://tbsortfolders/content/icon.png</em:iconURL>
     <em:name>Manually sort folders</em:name>
     <em:description>An extension that allows you to change the way Thunderbird sorts folders in the folder pane.</em:description>
     <em:creator>Jonathan Protzenko</em:creator>
+    <em:optionsType>3</em:optionsType>
     <em:optionsURL>chrome://tbsortfolders/content/tbsortfolders.xul</em:optionsURL>
 
     <em:targetApplication>


### PR DESCRIPTION
While the folder sorting part is still broken, this fixes some JS compatibilty problems with Thunerbird 60 (mainly about Application preference interfaces and Thunderbird restart). The UI for account sorting now works, but the one for folder sorting is still broken. Writing to folder sort preference is inhibited (commented out) so we don't risk destroying the existing sort order for those who have one existing from a previous Thunderbird version. Also using "pretty names" everywhere instead of "prettiest names" as the latter is deprecated and in practice identical to the first.