### PR TITLE
Fix "accountssort.warning" text.

### DIFF
--- a/locale/de/ui.dtd
+++ b/locale/de/ui.dtd
@@ -13,7 +13,7 @@
 <!ENTITY button.close "Schließen">
 <!ENTITY button.restart "Thunderbird neu starten">
 <!ENTITY accountssort.description "Diese Ansicht erlaubt die Sortierung der Konten in der Konten-/Ordneransicht. Im nächsten Tab können die Ordner innerhalb eines Kontos sortiert werden.">
-<!ENTITY accountsort.warning "E-Mail-Konten, Unix-Movemail-Konten sowie Blog- &amp; News-Feed-Konten müssen an oberster Position einsortiert erscheinen. Danach folgen die &quot;Lokalen Ordner&quot; und als letztes Newsgruppen-Konten. Diese Regelung kann umgangen werden, indem das Konto &quot;Lokale Ordner&quot; oder eins der Newsgruppen-Konten als Standardkonto ausgewählt wird, wodurch es an die oberste Position gesetzt wird.">
+<!ENTITY accountsort.warning "Standardmäßig erscheinen E-Mail-Konten, Unix-Movemail-Konten sowie Blog- &amp; News-Feed-Konten an oberster Position, danach folgen die &quot;Lokalen Ordner&quot; und als letztes Newsgruppen-Konten. Dies kann geändert werden, indem das Konto &quot;Lokale Ordner&quot; oder eins der Newsgruppen-Konten als Standardkonto ausgewählt wird, wodurch es an die oberste Position gesetzt wird.">
 <!ENTITY accountsort.restartwarning "Zur Übernahme der Änderungen muss Thunderbird neu gestartet werden.">
 <!ENTITY tab.accounts "Konten sortieren">
 <!ENTITY tab.folders "Ordner sortieren">

--- a/locale/en-US/ui.dtd
+++ b/locale/en-US/ui.dtd
@@ -13,7 +13,7 @@
 <!ENTITY button.close "Close">
 <!ENTITY button.restart "Restart Thunderbird">
 <!ENTITY accountssort.description "This panel allows you to order the accounts in the folder pane. Use next tab if you wish to sort folders inside an account.">
-<!ENTITY accountsort.warning "Regular mail accounts, Unix Movemail accounts as well as RSS accounts must come first. Local Folders are next, and at the bottom of the list are the News accounts. You can override this by choosing either Local Folders or one of the Newsgroup accounts as default, hence putting it on top of the list.">
+<!ENTITY accountsort.warning "Per default, regular mail accounts, Unix Movemail accounts as well as RSS accounts come first, &quot;Local Folders&quot; are next, and at the bottom of the list are the News accounts. You can override this by choosing either &quot;Local Folders&quot; or one of the Newsgroup accounts as default, hence putting it on top of the list.">
 <!ENTITY accountsort.restartwarning "You must restart Thunderbird for the changes to take effect.">
 <!ENTITY tab.accounts "Sort accounts">
 <!ENTITY tab.folders "Sort folders">


### PR DESCRIPTION
Changed English and German only. Other languages need to be checked by
people speaking that languages.

Fixes #89.