### PR TITLE
add account type for owl

### DIFF
--- a/content/ui.js
+++ b/content/ui.js
@@ -465,6 +465,7 @@ function accounts_on_load() {
       case "imap":
       case "pop3":
       case "exquilla":
+      case "owl":
       case "movemail":
       case "rss":
         mail_accounts.unshift([accounts[i], servers[i], types[i], names[i]]);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Manually sort folders",
   "description": "An extension that allows you to change the way Thunderbird sorts folders in the folder pane.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Jonathan Protzenko",
   "homepage_url": "http://wiki.github.com/protz/Manually-Sort-Folders/",
   "legacy": true,


### PR DESCRIPTION
This is a patch for 2.0.2 to add [Owl for Exchange](https://addons.thunderbird.net/en-US/thunderbird/addon/owl-for-exchange/) to the supported mail types.

It works and sorts for me, on Windows 10, using TB v68.9.0 (32-bit), and Owl v0.7.2